### PR TITLE
Added support for Alerts

### DIFF
--- a/Amethyst Authenticator Mac/Ressources/Assets.xcassets/amethystPurple.colorset/Contents.json
+++ b/Amethyst Authenticator Mac/Ressources/Assets.xcassets/amethystPurple.colorset/Contents.json
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "0.326",
+          "blue" : "0.325",
           "green" : "0.020",
-          "red" : "0.234"
+          "red" : "0.235"
         }
       },
       "idiom" : "universal"

--- a/Amethyst/Shared/ViewComponents/InputBar/InputBar.swift
+++ b/Amethyst/Shared/ViewComponents/InputBar/InputBar.swift
@@ -81,7 +81,8 @@ struct InputBar: View {
                 .focused($inputFocused)
                 .padding()
                 .background() {
-                    if #available(macOS 26.0, *) {                    RoundedRectangle(cornerRadius: 15)
+                    if #available(macOS 26.0, *) {
+                        RoundedRectangle(cornerRadius: 15)
                             .fill(textFieldBackgroundFill.opacity(0.3))
                     } else {
                         RoundedRectangle(cornerRadius: 5)

--- a/Amethyst/Shared/ViewComponents/WebKit/Delegates/WKUIDelegate.swift
+++ b/Amethyst/Shared/ViewComponents/WebKit/Delegates/WKUIDelegate.swift
@@ -54,7 +54,10 @@ extension WebViewModel: WKUIDelegate {
         alert.alertStyle = .informational
         alert.messageText = message
         
-        // TODO: Show website icon
+        if let window = webView.window {
+            await alert.beginSheetModal(for: window)
+            return
+        }
         alert.runModal()
     }
     
@@ -68,12 +71,17 @@ extension WebViewModel: WKUIDelegate {
         alert.alertStyle = .informational
         alert.addButton(withTitle: "OK")
         alert.addButton(withTitle: "Cancel")
-        // TODO: Show website icon
         alert.layout()
         
-        let result = alert.runModal()
+        var response: NSApplication.ModalResponse
         
-        return result == .alertFirstButtonReturn
+        if let window = webView.window {
+            response = await alert.beginSheetModal(for: window)
+        } else {
+            response = alert.runModal()
+        }
+        
+        return response == .alertFirstButtonReturn
     }
     
     func webView(
@@ -96,9 +104,18 @@ extension WebViewModel: WKUIDelegate {
         alert.layout()
         alert.window.initialFirstResponder = inputField
         
-        let result = alert.runModal()
-        
-        if result == .alertFirstButtonReturn {
+        if let window = webView.window {
+            alert.beginSheetModal(for: window) { response in
+                if response == .alertFirstButtonReturn {
+                    completionHandler(inputField.stringValue)
+                } else {
+                    completionHandler(nil)
+                }
+            }
+            return
+        }
+        let response = alert.runModal()
+        if response == .alertFirstButtonReturn {
             completionHandler(inputField.stringValue)
         } else {
             completionHandler(nil)

--- a/Amethyst/Shared/ViewComponents/WebKit/Delegates/WKUIDelegate.swift
+++ b/Amethyst/Shared/ViewComponents/WebKit/Delegates/WKUIDelegate.swift
@@ -45,6 +45,66 @@ extension WebViewModel: WKUIDelegate {
         }
     }
     
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo
+    ) async {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = message
+        
+        // TODO: Show website icon
+        alert.runModal()
+    }
+    
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo
+    ) async -> Bool {
+        let alert = NSAlert()
+        alert.messageText = message
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        // TODO: Show website icon
+        alert.layout()
+        
+        let result = alert.runModal()
+        
+        return result == .alertFirstButtonReturn
+    }
+    
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor (String?) -> Void
+    ) {
+        let alert = NSAlert()
+        alert.messageText = prompt
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: "Cancel")
+        
+        let inputField = NSTextField(frame: NSRect(x: 0, y: 0, width: 280, height: 24))
+        inputField.stringValue = defaultText ?? ""
+        alert.accessoryView = inputField
+        
+        alert.layout()
+        alert.window.initialFirstResponder = inputField
+        
+        let result = alert.runModal()
+        
+        if result == .alertFirstButtonReturn {
+            completionHandler(inputField.stringValue)
+        } else {
+            completionHandler(nil)
+        }
+    }
+    
     private func openInNewTab(configuration: WKWebViewConfiguration) -> WKWebView? {
         let newWebViewModel = WebViewModel(config: configuration, contentViewModel: contentViewModel, appViewModel: appViewModel)
         let newTab = ATab(webViewModel: newWebViewModel)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Alert Support Implementation

This PR adds comprehensive JavaScript dialog support to the WebKit integration and a few minor UI tweaks.

### Key Additions
- Implements WKUIDelegate handlers in WebViewModel:
  - Alert: webView(_:runJavaScriptAlertPanelWithMessage:initiatedByFrame:) — shows informational alerts (sheet when window available, modal otherwise).
  - Confirm: webView(_:runJavaScriptConfirmPanelWithMessage:initiatedByFrame:) async -> Bool — OK/Cancel confirm dialogs, returns boolean result.
  - Text input: webView(_:runJavaScriptTextInputPanelWithPrompt:defaultText:initiatedByFrame:completionHandler:) — input dialog with NSTextField accessory, returns entered string or nil; supports sheet and modal presentation and sets the text field as initial first responder.

- openInNewTab(configuration:) now creates and inserts a new ATab adjacent to the current tab (or appends), updates contentViewModel.currentTab to activate the new tab, and returns the new web view. createWebViewWith(...) uses this for new-tab actions and properly handles openInBackground/openInNewWindow cases.

### Minor Changes
- InputBar.swift: formatting adjusted for macOS availability branch (styling unchanged).
- amethystPurple.colorset/Contents.json: tiny color component adjustments in dark appearance.

### Notable quality
- The text-input dialog is well-crafted: sized NSTextField accessory, first-responder handling, and correct sheet/modal completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->