### PR TITLE
Added support for quick access urls via :key and moved bangs to !key

### DIFF
--- a/Amethyst/Main/AppDelegate.swift
+++ b/Amethyst/Main/AppDelegate.swift
@@ -42,6 +42,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     func applicationDidFinishLaunching(_ notification: Notification) {
         BangManager.shared.fetch()
+        CommandsManager.shared.fetch()
         DispatchQueue.main.async {
             let hasVisibleContentWindows = NSApp.windows.contains { window in
                 window.isVisible && window.canBecomeMain

--- a/Amethyst/Main/Views/Settings/SettingsView.swift
+++ b/Amethyst/Main/Views/Settings/SettingsView.swift
@@ -47,7 +47,7 @@ struct SettingsView: View {
                     Label("Design", systemImage: "paintbrush.pointed")
                 }
                 Tab {
-                    BangSettings()
+                    ProductivitySettings()
                 } label: {
                     Label("Productivity", systemImage: "chart.bar")
                 }
@@ -125,8 +125,8 @@ struct SettingsView: View {
         }
     }
     
-    struct BangSettings: View {
-        @State var bangManager = BangManager.shared
+    struct ShortcutEditView: View {
+        @State var manager: ShortcutFeatureManager
         @State var showTemporary = false
         
         var body: some View {
@@ -146,23 +146,25 @@ struct SettingsView: View {
                 }
                 .foregroundStyle(.secondary)
                 if showTemporary {
-                    BangRow(shortcut: "", destination: "") {
+                    ShortcutRow(manager: manager, shortcut: "", destination: "") {
                         self.showTemporary = false
                     }
                 }
-                ForEach(bangManager.registered.keys.sorted()) { key in
-                    BangRow(shortcut: key, destination: bangManager.registered[key]!)
+                ForEach(manager.registered.keys.sorted()) { key in
+                    ShortcutRow(manager: manager, shortcut: key, destination: manager.registered[key]!)
                 }
             }
         }
-        struct BangRow: View {
+        struct ShortcutRow: View {
+            let manager: ShortcutFeatureManager
             @State var shortcut: String
             @State var destination: String
             let oldShortcut: String
             let oldDestination: String
             let onPersist: (() -> Void)?
             
-            init(shortcut: String, destination: String, onPersist: (() -> Void)? = nil) {
+            init(manager: ShortcutFeatureManager, shortcut: String, destination: String, onPersist: (() -> Void)? = nil) {
+                self.manager = manager
                 self._shortcut = State(initialValue: shortcut)
                 self._destination = State(initialValue: destination)
                 self.oldShortcut = shortcut
@@ -178,17 +180,58 @@ struct SettingsView: View {
                     TextField("", text: $destination)
                     Button("Save") {
                         if shortcut != oldShortcut {
-                            BangManager.shared.remove(key: oldShortcut)
+                            manager.remove(key: oldShortcut)
                         }
-                        BangManager.shared.set(destination, for: shortcut)
+                        manager.set(destination, for: shortcut)
                         onPersist?()
                     }
                     .disabled(shortcut.isEmpty || destination.isEmpty || (shortcut == oldShortcut && destination == oldDestination))
                     Button {
-                        BangManager.shared.remove(key: oldShortcut)
+                        manager.remove(key: oldShortcut)
                         onPersist?()
                     } label: {
                         Image(systemName: "minus")
+                    }
+                }
+            }
+        }
+    }
+    
+    struct ProductivitySettings: View {
+        @State private var selection = ProductivityView.bangs
+        var body: some View {
+            HStack {
+                ForEach(ProductivityView.allCases, id: \.rawValue) { feature in
+                    feature.button(selection: $selection)
+                }
+            }
+            switch selection {
+                case .bangs:
+                    ShortcutEditView(manager: BangManager.shared)
+                case .commands:
+                    ShortcutEditView(manager: CommandsManager.shared)
+            }
+        }
+        
+        private enum ProductivityView: String, CaseIterable {
+            case bangs = "Bang Queries"
+            case commands = "Commands"
+            
+            @ViewBuilder
+            func button(selection: Binding<Self>) -> some View {
+                if #available(macOS 26, *) {
+                    Button(rawValue) {
+                        selection.wrappedValue = self
+                    }
+                    .if(selection.wrappedValue == self) { view in
+                        view.buttonStyle(.glassProminent)
+                    }
+                } else {
+                    Button(rawValue) {
+                        selection.wrappedValue = self
+                    }
+                    .if(selection.wrappedValue == self) { view in
+                        view.buttonStyle(.borderedProminent)
                     }
                 }
             }

--- a/Amethyst/Main/Views/Settings/SettingsView.swift
+++ b/Amethyst/Main/Views/Settings/SettingsView.swift
@@ -126,7 +126,7 @@ struct SettingsView: View {
     }
     
     struct ShortcutEditView: View {
-        @State var manager: ShortcutFeatureManager
+        let manager: ShortcutFeatureManager
         @State var showTemporary = false
         
         var body: some View {

--- a/Amethyst/Shared/Enumerations/SearchSuggestionOrigin.swift
+++ b/Amethyst/Shared/Enumerations/SearchSuggestionOrigin.swift
@@ -1,15 +1,11 @@
-//
-//  SearchSuggestionOrigin.swift
-//  Amethyst Browser
-//
-//  Created by Mia Koring on 02.12.24.
-//
+
 import SwiftUI
 
 enum SearchSuggestionOrigin {
     case history
     case searchEngine
     case bang
+    case command
 }
 
 extension SearchSuggestionOrigin {
@@ -17,7 +13,7 @@ extension SearchSuggestionOrigin {
         switch self {
             case .searchEngine:
                 (SearchEngine(rawValue: UDKey.searchEngine.intValue) ?? .duckduckgo).icon
-            case .history, .bang:
+            case .history, .bang, .command:
                 Image("AmethystLogo")
         }
     }

--- a/Amethyst/Shared/Enumerations/UDKey.swift
+++ b/Amethyst/Shared/Enumerations/UDKey.swift
@@ -17,6 +17,7 @@ enum UDKey: String, CaseIterable, UserDefaultWrapper {
     case useOldDesign
     case tranclucency
     case bangs
+    case commands
     
     case userEmail
 }

--- a/Amethyst/Shared/Manager/BangManager.swift
+++ b/Amethyst/Shared/Manager/BangManager.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 @Observable
-final class BangManager {
+final class BangManager: ShortcutFeatureManager {
     static var shared = BangManager()
     
     private init() {}
@@ -13,7 +13,7 @@ final class BangManager {
     }
     
     func resolve(_ query: String) -> String? {
-        guard query.hasPrefix(":") else { return nil }
+        guard query.hasPrefix("!") else { return nil }
         
         let parts = query
             .dropFirst()
@@ -67,4 +67,11 @@ final class BangManager {
         else { return }
         bangs = decoded
     }
+}
+protocol ShortcutFeatureManager: Observable {
+    func fetch() -> Void
+    func set(_ destination: String, for key: String) -> Void
+    func remove(key: String)
+    func resolve(_ query: String) -> String?
+    var registered: [String: String] { get }
 }

--- a/Amethyst/Shared/Manager/CommandsManager.swift
+++ b/Amethyst/Shared/Manager/CommandsManager.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+
+@Observable
+final class CommandsManager: ShortcutFeatureManager {
+    static var shared = CommandsManager()
+    
+    private init() {}
+    
+    private var commands = [String: String]()
+    
+    var registered: [String: String] {
+        commands
+    }
+    
+    func resolve(_ query: String) -> String? {
+        guard query.hasPrefix(":") else { return nil }
+        
+        let key = "\(query.dropFirst())"
+        
+        guard
+            let destination = commands[key]
+        else { return nil }
+        
+        return "\(destination)"
+    }
+    
+    func remove(key: String) {
+        guard
+            let commandsData = UDKey.commands.data,
+            var decoded = try? JSONDecoder().decode([String: String].self, from: commandsData)
+        else {
+            commands = [:]
+            UDKey.commands.data = nil
+            return
+        }
+        
+        decoded[key] = nil
+        commands = decoded
+        
+        UDKey.commands.data = try? JSONEncoder().encode(decoded)
+    }
+    
+    func set(_ destination: String, for key: String) {
+        guard
+            let commandsData = UDKey.commands.data,
+            var decoded = try? JSONDecoder().decode([String: String].self, from: commandsData)
+        else {
+            commands = [key: destination]
+            UDKey.commands.data = try? JSONEncoder().encode(commands)
+            return
+        }
+        
+        decoded[key] = destination
+        commands = decoded
+        
+        UDKey.commands.data = try? JSONEncoder().encode(decoded)
+    }
+    
+    func fetch() {
+        guard
+            let commandsData = UDKey.commands.data,
+            let decoded = try? JSONDecoder().decode([String: String].self, from: commandsData)
+        else { return }
+        commands = decoded
+    }
+}

--- a/Amethyst/Shared/Protocols/TabOpener.swift
+++ b/Amethyst/Shared/Protocols/TabOpener.swift
@@ -85,6 +85,10 @@ fileprivate struct InputParser {
         if let bangResult = BangManager.shared.resolve(text) {
             text = bangResult
         }
+        
+        if let shortcut = CommandsManager.shared.resolve(text) {
+            text = shortcut
+        }
 
         // Then, try to interpret the text as a URL
         if let url = createURL(from: text) {

--- a/Amethyst/Shared/ViewComponents/InputBar/InputBarFunctions.swift
+++ b/Amethyst/Shared/ViewComponents/InputBar/InputBarFunctions.swift
@@ -14,6 +14,10 @@ extension InputBar {
             quickSearchResults = [SearchSuggestion(title: text, urlString: bang, origin: .bang)]
             return
         }
+        if let command = CommandsManager.shared.resolve(text) {
+            quickSearchResults = [SearchSuggestion(title: text, urlString: command, origin: .command)]
+            return
+        }
         if let meili = appViewModel.meili {
             async let results = await fetchSearchEngineSuggestions()
             async let meiliRes = await fetchHistorySuggestions(meili)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR adds support for quick-access command shortcuts using the `:key` syntax while refactoring existing bang shortcuts to use `!key` syntax. The implementation introduces a new `CommandsManager` singleton and a shared `ShortcutFeatureManager` protocol to manage both feature types consistently.

## Key Changes

**New Components:**
- **CommandsManager**: New singleton manager for command shortcuts (`:key` syntax), providing `fetch()`, `set()`, `remove()`, and `resolve()` methods with JSON-based persistence via `UDKey.commands`
- **ShortcutFeatureManager Protocol**: Shared protocol implemented by both `BangManager` and `CommandsManager`, defining the interface for shortcut resolution and management

**Refactored Components:**
- **BangManager**: Now conforms to `ShortcutFeatureManager`; prefix check changed from `:` to `!` to align with new syntax
- **Settings UI**: Replaced `BangSettings` with `ShortcutEditView` and `BangRow` with `ShortcutRow`, introducing a manager-based architecture that allows reuse for both bangs and commands via `ProductivitySettings` view with feature selection
- **Input Resolution**: Updated `InputParser.parse()` and `InputBarFunctions.timerSuggestionFetch()` to resolve commands via `CommandsManager`, with command resolution occurring before MeiliSearch/history evaluation for optimized performance
- **Enumerations**: Added `command` case to `SearchSuggestionOrigin` and `commands` case to `UDKey` to support the new feature throughout the app

**Application Startup:**
- `AppDelegate.applicationDidFinishLaunching()` now calls both `CommandsManager.shared.fetch()` and `BangManager.shared.fetch()` for initialization

## Design Highlights
The implementation demonstrates solid architectural choices: the `ShortcutFeatureManager` protocol eliminates duplication by providing a common interface for both feature types, the manager-based settings view enables seamless reuse across different shortcut contexts, and strategic command resolution placement (before search operations) indicates thoughtful performance consideration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->