### PR TITLE
Improve history browsing and sync

### DIFF
--- a/Amethyst/Main/ContentView.swift
+++ b/Amethyst/Main/ContentView.swift
@@ -47,6 +47,15 @@ extension ContentView: View, TabOpener {
                 .frame(maxWidth: max(550, min(reader.size.width / 2, 800)))
             }
             .clipShape(RoundedRectangle(cornerRadius: 10))
+            .overlay {
+                if showHistory {
+                    HistoryOverlay(
+                        isPresented: $showHistory,
+                        modalSize: $historyModalSize,
+                        containerSize: reader.size
+                    )
+                }
+            }
             .onAppear(perform: onAppear)
             .onDisappear {
                 NotificationCenter.default.removeObserver(
@@ -59,10 +68,7 @@ extension ContentView: View, TabOpener {
             .onChange(of: contentViewModel.tabs) { if contentViewModel.tabs.isEmpty { contentViewModel.isSidebarShown = true } }
             .onChange(of: contentViewModel.currentTab) { if contentViewModel.currentTab != nil { contentViewModel.isLoaded = true } }
             .onChange(of: contentViewModel.showHistory) { showHistory = contentViewModel.showHistory }
-            .sheet(isPresented: $showHistory) { contentViewModel.showHistory = false } content: {
-                HistoryView()
-                    .frame(width: 400, height: 500)
-            }
+            .onChange(of: showHistory) { contentViewModel.showHistory = showHistory }
             .sheet(isPresented: $appViewModel.showsSetup) { appViewModel.showsSetup = false } content: {
                 Setup()
                     .frame(width: 700, height: 400)
@@ -74,7 +80,7 @@ extension ContentView: View, TabOpener {
             appViewModel.displayedWindows[id] = nil
         }
     }
-    
+
     private struct MacOSWindowButtonsOverlay: View {
         @Binding var macosWindowIconsHovered: Bool
         var body: some View {
@@ -97,12 +103,99 @@ extension ContentView: View, TabOpener {
             }
         }
     }
-    
+
+    private struct HistoryOverlay: View {
+        @Binding var isPresented: Bool
+        @Binding var modalSize: CGSize
+        let containerSize: CGSize
+
+        private let minWidth: CGFloat = 400
+        private let minHeight: CGFloat = 500
+        @State private var resizeStartSize: CGSize?
+
+        var body: some View {
+            ZStack {
+                Color.black.opacity(0.18)
+                    .contentShape(Rectangle())
+                    .onTapGesture {
+                        isPresented = false
+                    }
+
+                HistoryView()
+                    .frame(width: clampedWidth, height: clampedHeight)
+                    .background {
+                        RoundedRectangle(cornerRadius: 22)
+                            .fill(.regularMaterial)
+                            .shadow(color: .black.opacity(0.25), radius: 25, y: 12)
+                    }
+                    .overlay(alignment: .bottomTrailing) {
+                        Image(systemName: "arrow.up.left.and.arrow.down.right")
+                            .font(.caption.bold())
+                            .foregroundStyle(.secondary)
+                            .padding(12)
+                            .contentShape(Rectangle())
+                            .gesture(resizeGesture)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 22))
+                    .contentShape(RoundedRectangle(cornerRadius: 22))
+                    .onTapGesture {
+                        // Keep taps inside the modal from dismissing the overlay.
+                    }
+                    .onKeyPress(.escape) {
+                        isPresented = false
+                        return .handled
+                    }
+            }
+            .transition(.opacity.animation(.linear(duration: 0.12)))
+        }
+
+        private var clampedWidth: CGFloat {
+            clamp(modalSize.width, min: minWidth, max: max(minWidth, containerSize.width - 80))
+        }
+
+        private var clampedHeight: CGFloat {
+            clamp(modalSize.height, min: minHeight, max: max(minHeight, containerSize.height - 80))
+        }
+
+        private var resizeGesture: some Gesture {
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    let startSize = resizeStartSize ?? modalSize
+                    if resizeStartSize == nil {
+                        resizeStartSize = modalSize
+                    }
+
+                    let newWidth = clamp(
+                        startSize.width + value.translation.width * 2,
+                        min: minWidth,
+                        max: max(minWidth, containerSize.width - 80)
+                    )
+                    let newHeight = clamp(
+                        startSize.height + value.translation.height * 2,
+                        min: minHeight,
+                        max: max(minHeight, containerSize.height - 80)
+                    )
+
+                    modalSize = CGSize(
+                        width: newWidth,
+                        height: newHeight
+                    )
+                }
+                .onEnded { _ in
+                    resizeStartSize = nil
+                }
+        }
+
+        private func clamp(_ value: CGFloat, min minValue: CGFloat, max maxValue: CGFloat) -> CGFloat {
+            Swift.min(Swift.max(value, minValue), maxValue)
+        }
+    }
+
     private struct FixedSidebar: View {
         @Environment(ContentViewModel.self) private var contentViewModel
         @State private var width: CGFloat
         let edge: HorizontalEdge
-        
+
         init(edge: HorizontalEdge) {
             self.edge = edge
             let storedWidth = edge == .trailing ? UDKey.trailingFixedSidebarWidth.doubleValue: UDKey.leadingFixedSidebarWidth.doubleValue
@@ -173,7 +266,7 @@ extension ContentView: View, TabOpener {
             }
         }
     }
-    
+
     private struct FloatingSidebars: View {
         @Environment(ContentViewModel.self) var contentViewModel
         var body: some View {
@@ -189,9 +282,9 @@ extension ContentView: View, TabOpener {
                 }
             }
         }
-        
+
     }
-    
+
     private struct InlineSearch: View {
         @Environment(ContentViewModel.self) var contentViewModel
         var body: some View {
@@ -209,7 +302,7 @@ extension ContentView: View, TabOpener {
             }
         }
     }
-    
+
     private struct WindowHighlighter: View {
         @Environment(AppViewModel.self) var appViewModel
         @Environment(ContentViewModel.self) var contentViewModel
@@ -229,7 +322,7 @@ extension ContentView: View, TabOpener {
             }
         }
     }
-    
+
     private struct MacosButtonHoverArea: View {
         @Binding var showMacosWindowIconsAreaHovered: Bool
         var body: some View {
@@ -248,7 +341,5 @@ extension ContentView: View, TabOpener {
             }
         }
     }
-    
+
 }
-
-

--- a/Amethyst/Main/ContentViewModel.swift
+++ b/Amethyst/Main/ContentViewModel.swift
@@ -28,16 +28,16 @@ class ContentViewModel: NSObject, ObservableObject, Identifiable {
     var isLoaded: Bool = false
     var sidebarOrientation: SidebarOrientations
     var showSetup: Bool = false
-    
+
     var window: NSWindow? = nil
-    
+
     var onClose: (() -> Void)?
-    
+
     init(id: String) {
         self.id = id
         self.sidebarOrientation = UDKey.sidebarOrientation.boolValue ? .tabsTrailing: .tabsLeading
     }
-    
+
     func handleClose() {
         guard let index = tabs.firstIndex(where: {$0.id == currentTab}) else { return }
         if tabs.count > 1 {
@@ -48,12 +48,12 @@ class ContentViewModel: NSObject, ObservableObject, Identifiable {
             currentTab = nil
         }
     }
-    
-    
+
+
     func tabFor(id: UUID?) -> ATab? {
         return tabs.first(where: {$0.id == id})
     }
-    
+
     func closeTab(id: UUID) {
         Task {
             await tabs.first(where: {$0.id == id})?.webViewModel.cleanup()
@@ -63,7 +63,7 @@ class ContentViewModel: NSObject, ObservableObject, Identifiable {
             tabs.removeAll(where: {$0.id == id})
         }
     }
-    
+
     func changeToTab(id: UUID) {
         if let currentTab = tabs.first(where: {$0.id == currentTab}) {
             currentTab.webViewModel.removeHighlights()
@@ -75,7 +75,7 @@ class ContentViewModel: NSObject, ObservableObject, Identifiable {
 
 struct ContentView {
     static let logger = Logger(subsystem: AmethystApp.subSystem, category: "ContentViewModel")
-    
+
     @Environment(AppViewModel.self) var appViewModel: AppViewModel
     @Environment(ContentViewModel.self) var contentViewModel: ContentViewModel
     @Environment(\.dismissWindow) var dismissWindow
@@ -85,7 +85,8 @@ struct ContentView {
     @State var macosWindowIconsHovered: Bool = false
     @Environment(\.scenePhase) var scenePhase
     @State var showHistory = false
-    
+    @State var historyModalSize = CGSize(width: 400, height: 500)
+
     func onAppear() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
             if let window = contentViewModel.window, let id = window.identifier?.rawValue {
@@ -110,21 +111,21 @@ struct ContentView {
                 return
             }
         }
-        
+
         if let newURL = appViewModel.newURLToOpen {
             appViewModel.newURLToOpen = nil
-            
+
             let vm = WebViewModel(contentViewModel: contentViewModel, appViewModel: appViewModel)
             vm.load(url: newURL)
             let newTab = ATab(webViewModel: vm)
-            
+
             contentViewModel.tabs.append(newTab)
             contentViewModel.currentTab = newTab.id
         }
         if contentViewModel.tabs.isEmpty {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
                 let savedTabs = CDTabController.fetchAllFor(windowID: contentViewModel.id)
-                
+
                 var memoizedIDs = [UUID]()
                 for savedTab in savedTabs {
                     guard let id = savedTab.tabID, !memoizedIDs.contains(id) else {
@@ -143,4 +144,3 @@ struct ContentView {
     }
 
 }
-

--- a/Amethyst/Main/Views/History/HistoryCanonicalizer.swift
+++ b/Amethyst/Main/Views/History/HistoryCanonicalizer.swift
@@ -1,0 +1,33 @@
+//
+//  HistoryCanonicalizer.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import Foundation
+
+enum HistoryCanonicalizer {
+    static func canonicalURLString(for url: URL) -> String {
+        guard var components = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+            return url.absoluteString
+        }
+
+        components.fragment = nil
+        components.scheme = components.scheme?.lowercased()
+        components.host = components.host?.lowercased()
+
+        if let port = components.port, let scheme = components.scheme {
+            let isDefaultPort = (scheme == "http" && port == 80) || (scheme == "https" && port == 443)
+            if isDefaultPort {
+                components.port = nil
+            }
+        }
+
+        if components.path.isEmpty {
+            components.path = "/"
+        }
+
+        return components.string ?? url.absoluteString
+    }
+}

--- a/Amethyst/Main/Views/History/HistoryDaySection.swift
+++ b/Amethyst/Main/Views/History/HistoryDaySection.swift
@@ -1,0 +1,21 @@
+//
+//  HistoryDaySection.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import Foundation
+
+struct HistoryDaySection: Identifiable {
+    let dayTime: Double
+    let pages: [HistoryGroupedPage]
+
+    var id: Double {
+        dayTime
+    }
+
+    var title: String {
+        Date(timeIntervalSinceReferenceDate: dayTime).formatted(date: .numeric, time: .omitted)
+    }
+}

--- a/Amethyst/Main/Views/History/HistoryGroupedPage.swift
+++ b/Amethyst/Main/Views/History/HistoryGroupedPage.swift
@@ -1,0 +1,61 @@
+//
+//  HistoryGroupedPage.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import Foundation
+
+struct HistoryGroupedPage: Identifiable {
+    let dayTime: Double
+    let canonicalURL: String
+    let visits: [HistoryVisitRow]
+
+    init(dayTime: Double, canonicalURL: String, visits: [HistoryVisitRow]) {
+        self.dayTime = dayTime
+        self.canonicalURL = canonicalURL
+        self.visits = visits.sorted(by: { $0.time > $1.time })
+    }
+
+    var id: String {
+        "\(dayTime)|\(canonicalURL)"
+    }
+
+    var latestVisit: HistoryVisitRow {
+        visits[0]
+    }
+
+    var displayTitle: String {
+        visits.first(where: { $0.rawTitle != nil })?.displayTitle ?? latestVisit.displayTitle
+    }
+
+    var displayURL: String {
+        latestVisit.urlString
+    }
+
+    var host: String {
+        latestVisit.host
+    }
+
+    var lastVisitedTime: Double {
+        latestVisit.time
+    }
+
+    var visitCount: Int {
+        visits.count
+    }
+
+    func matches(searchText: String) -> Bool {
+        guard !searchText.isEmpty else { return true }
+
+        if displayTitle.localizedCaseInsensitiveContains(searchText) || host.localizedCaseInsensitiveContains(searchText) {
+            return true
+        }
+
+        return visits.contains(where: {
+            $0.urlString.localizedCaseInsensitiveContains(searchText) ||
+            ($0.rawTitle?.localizedCaseInsensitiveContains(searchText) ?? false)
+        })
+    }
+}

--- a/Amethyst/Main/Views/History/HistoryListView.swift
+++ b/Amethyst/Main/Views/History/HistoryListView.swift
@@ -10,22 +10,30 @@ import SwiftUI
 
 struct HistoryListView: View {
     @Environment(ContentViewModel.self) private var contentViewModel
-    @Environment(AppViewModel.self) var appViewModel
-    let items: [HistoryItem]
-    let proxy: ScrollViewProxy
-    @FocusState var focusedItem: Int?
+    let pages: [HistoryGroupedPage]
+    @Binding var expandedPageIDs: Set<String>
+    let onDeleteVisit: (HistoryVisitRow) -> Void
+    let onDeletePage: (HistoryGroupedPage) -> Void
     @State var shiftPressed: Bool = false
-    
+
     var body: some View {
-        LazyVStack {
-            ForEach(items, id: \.id) { item in
-                HistoryRow(item: item, focusedItem: $focusedItem, shiftPressed: $shiftPressed)
+        LazyVStack(spacing: 10) {
+            ForEach(pages) { page in
+                HistoryPageRow(
+                    page: page,
+                    isExpanded: expandedPageIDs.contains(page.id),
+                    shiftPressed: $shiftPressed,
+                    toggleExpanded: {
+                        toggleExpanded(pageID: page.id)
+                    },
+                    onDeleteVisit: onDeleteVisit,
+                    onDeletePage: onDeletePage
+                )
             }
         }
-        .onChange(of: focusedItem, focusedItemChanged)
         .onKeyPress(phases: [.down, .up], action: keyPressed)
     }
-    
+
     private func keyPressed(_ event: KeyPress) -> KeyPress.Result {
         if event.modifiers == .shift {
             shiftPressed = event.phase == .down
@@ -33,57 +41,104 @@ struct HistoryListView: View {
         }
         return .ignored
     }
-    
-    private func focusedItemChanged() {
-        if let focusedItem {
-            withAnimation(.linear) {
-                proxy.scrollTo(focusedItem, anchor: .center)
+
+    private func toggleExpanded(pageID: String) {
+        withAnimation(.linear(duration: 0.15)) {
+            if expandedPageIDs.contains(pageID) {
+                expandedPageIDs.remove(pageID)
+            } else {
+                expandedPageIDs.insert(pageID)
             }
         }
     }
-    
-    struct HistoryRow: View {
-        let item: HistoryItem
-        var focusedItem: FocusState<Int?>.Binding
+
+    struct HistoryPageRow: View {
+        let page: HistoryGroupedPage
+        let isExpanded: Bool
         @Environment(AppViewModel.self) var appViewModel
         @Environment(ContentViewModel.self) var contentViewModel
         @Environment(\.dismiss) var dismiss
         @Binding var shiftPressed: Bool
-        
+        let toggleExpanded: () -> Void
+        let onDeleteVisit: (HistoryVisitRow) -> Void
+        let onDeletePage: (HistoryGroupedPage) -> Void
+
         var body: some View {
-            Button {
-                openItem(item)
-            } label: {
-                HStack {
-                    VStack(alignment: .leading) {
-                        Text(topText())
-                            .font(.title2)
-                            .lineLimit(1)
-                        Text(item.url?.absoluteString ?? "")
-                            .font(.caption)
-                            .lineLimit(1)
+            VStack(alignment: .leading, spacing: 10) {
+                HStack(alignment: .top, spacing: 10) {
+                    Button(action: toggleExpanded) {
+                        VStack(alignment: .leading, spacing: 4) {
+                            Text(page.displayTitle)
+                                .font(.title3.weight(.semibold))
+                                .lineLimit(1)
+                            Text(page.displayURL)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                            HStack(spacing: 8) {
+                                Label(
+                                    "\(page.visitCount) \(page.visitCount == 1 ? "visit" : "visits")",
+                                    systemImage: "clock.arrow.circlepath"
+                                )
+                                Text(Date(timeIntervalSinceReferenceDate: page.lastVisitedTime).formatted(date: .omitted, time: .shortened))
+                            }
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        }
+                        .frame(maxWidth: .infinity, alignment: .leading)
                     }
-                    Spacer()
+                    .buttonStyle(.plain)
+
+                    ActionButton(systemName: "arrow.up.forward.square") {
+                        openURL(page.latestVisit.url)
+                    }
+                    .help("Open page")
+
+                    ActionButton(systemName: "trash", role: .destructive) {
+                        onDeletePage(page)
+                    }
+                    .help("Delete all visits for this page")
+
+                    ActionButton(systemName: isExpanded ? "chevron.up" : "chevron.down") {
+                        toggleExpanded()
+                    }
+                    .help(isExpanded ? "Collapse visits" : "Expand visits")
                 }
-                .padding(10)
-                .background() {
-                    RoundedRectangle(cornerRadius: 15)
-                        .fill(.ultraThinMaterial)
+
+                if isExpanded {
+                    VStack(spacing: 6) {
+                        ForEach(page.visits) { visit in
+                            VisitRow(
+                                visit: visit,
+                                shiftPressed: $shiftPressed,
+                                onDelete: {
+                                    onDeleteVisit(visit)
+                                }
+                            )
+                        }
+                    }
+                    .padding(.leading, 12)
                 }
             }
-            .buttonStyle(.plain)
-            .focused(focusedItem, equals: item.id)
-        }
-        
-        func topText() -> String {
-            guard let title = item.title, !title.isEmpty else {
-                return item.url?.host() ?? item.url?.absoluteString ?? ""
+            .padding(12)
+            .background {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(.white.opacity(0.08))
             }
-            return title
+            .contextMenu {
+                Button("Open") {
+                    openURL(page.latestVisit.url)
+                }
+                Button(isExpanded ? "Collapse Visits" : "Expand Visits") {
+                    toggleExpanded()
+                }
+                Button("Delete All Visits", role: .destructive) {
+                    onDeletePage(page)
+                }
+            }
         }
-        
-        func openItem(_ item: HistoryItem) {
-            guard let url = item.url else { return }
+
+        func openURL(_ url: URL) {
             let vm = WebViewModel(contentViewModel: contentViewModel, appViewModel: appViewModel)
             vm.load(urlString: url.absoluteString)
             let tab = ATab(webViewModel: vm)
@@ -94,5 +149,93 @@ struct HistoryListView: View {
             }
         }
     }
-    
+
+    struct VisitRow: View {
+        let visit: HistoryVisitRow
+        @Environment(AppViewModel.self) var appViewModel
+        @Environment(ContentViewModel.self) var contentViewModel
+        @Environment(\.dismiss) var dismiss
+        @Binding var shiftPressed: Bool
+        let onDelete: () -> Void
+
+        var body: some View {
+            HStack(alignment: .top, spacing: 10) {
+                HStack {
+                    VStack(alignment: .leading) {
+                        Text(visit.displayTitle)
+                            .font(.body)
+                            .lineLimit(1)
+                        Text(visit.urlString)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                        Text(Date(timeIntervalSinceReferenceDate: visit.time).formatted(date: .omitted, time: .shortened))
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Spacer()
+                }
+
+                ActionButton(systemName: "arrow.up.forward.square") {
+                    openItem(visit.url)
+                }
+                .help("Open visit")
+
+                ActionButton(systemName: "trash", role: .destructive) {
+                    onDelete()
+                }
+                .help("Delete visit")
+            }
+            .padding(10)
+            .background {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(.thinMaterial)
+            }
+            .contextMenu {
+                Button("Open") {
+                    openItem(visit.url)
+                }
+                Button("Delete Visit", role: .destructive) {
+                    onDelete()
+                }
+            }
+        }
+
+        func openItem(_ url: URL) {
+            let vm = WebViewModel(contentViewModel: contentViewModel, appViewModel: appViewModel)
+            vm.load(urlString: url.absoluteString)
+            let tab = ATab(webViewModel: vm)
+            contentViewModel.tabs.append(tab)
+            if !shiftPressed {
+                contentViewModel.currentTab = tab.id
+                dismiss()
+            }
+        }
+    }
+
+    private struct ActionButton: View {
+        let systemName: String
+        let role: ButtonRole?
+        let action: () -> Void
+
+        init(systemName: String, role: ButtonRole? = nil, action: @escaping () -> Void) {
+            self.systemName = systemName
+            self.role = role
+            self.action = action
+        }
+
+        var body: some View {
+            Button(role: role, action: action) {
+                Image(systemName: systemName)
+                    .frame(width: 18, height: 18)
+                    .padding(6)
+                    .background {
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(.thinMaterial)
+                    }
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
 }

--- a/Amethyst/Main/Views/History/HistoryView.swift
+++ b/Amethyst/Main/Views/History/HistoryView.swift
@@ -5,34 +5,150 @@
 //  Created by Mia Koring on 04.12.24.
 //
 
-import CoreData
 import SwiftUI
 
 struct HistoryView: View {
-    @State private var days = [HistoryDay]()
-    
+    @Environment(AppViewModel.self) private var appViewModel
+    @State private var viewModel = HistoryViewModel()
+    @FocusState private var searchFieldFocused: Bool
+
     var body: some View {
+        @Bindable var viewModel = viewModel
+
         BackgroundView(shouldRotate: false) {
-            ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack {
-                        ForEach(days) { day in
-                            DetailView(title: Text(
-                                "\(Date(timeIntervalSinceReferenceDate: day.dayTime).toString(with: "dd.MM.yyyy"))"
-                            ), isExpanded: false) {
-                                HistoryListView(items: day.sortedItems, proxy: proxy)
+            VStack(alignment: .leading, spacing: 16) {
+                HStack(spacing: 10) {
+                    Image(systemName: "magnifyingglass")
+                        .foregroundStyle(.secondary)
+                    TextField("Search history", text: $viewModel.searchText)
+                        .textFieldStyle(.plain)
+                        .focused($searchFieldFocused)
+                    if !viewModel.searchText.isEmpty {
+                        Button {
+                            viewModel.searchText = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill")
+                                .foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
+                .background {
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(.ultraThinMaterial)
+                }
+
+                HStack {
+                    Text("\(viewModel.resultCount) \(viewModel.resultCount == 1 ? "page" : "pages")")
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    if viewModel.hasHistory {
+                        Button("Clear History", role: .destructive) {
+                            viewModel.showClearAllConfirmation = true
+                        }
+                        .buttonStyle(.borderless)
+                    }
+                }
+
+                Group {
+                    if !viewModel.hasHistory {
+                        EmptyStateView(
+                            title: "No history yet",
+                            subtitle: "Pages you open will start showing up here."
+                        )
+                    } else if !viewModel.hasSearchResults {
+                        EmptyStateView(
+                            title: "No results",
+                            subtitle: "Try searching by title, host, or URL."
+                        )
+                    } else {
+                        ScrollView {
+                            LazyVStack(alignment: .leading, spacing: 16) {
+                                ForEach(viewModel.sections) { section in
+                                    VStack(alignment: .leading, spacing: 12) {
+                                        Text(section.title)
+                                            .font(.headline)
+                                        HistoryListView(
+                                            pages: section.pages,
+                                            expandedPageIDs: $viewModel.expandedPageIDs,
+                                            onDeleteVisit: { visit in
+                                                viewModel.deleteVisit(visit, meili: appViewModel.meili)
+                                            },
+                                            onDeletePage: { page in
+                                                viewModel.confirmDeletePage(page)
+                                            }
+                                        )
+                                    }
+                                    .padding(14)
+                                    .background {
+                                        RoundedRectangle(cornerRadius: 18)
+                                            .fill(.ultraThinMaterial)
+                                    }
+                                }
                             }
-                            .listRowSeparator(.hidden)
+                            .padding(.bottom, 4)
                         }
                     }
-                    .padding()
                 }
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             }
         }
+        .padding()
+        .confirmationDialog(
+            "Delete all browsing history?",
+            isPresented: $viewModel.showClearAllConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Clear History", role: .destructive) {
+                viewModel.clearAllHistory(meili: appViewModel.meili)
+            }
+        } message: {
+            Text("This removes all saved history entries and clears their omnibox suggestions.")
+        }
+        .confirmationDialog(
+            "Delete all visits for \(viewModel.pendingPageDeletion?.displayTitle ?? "this page")?",
+            isPresented: Binding(
+                get: { viewModel.pendingPageDeletion != nil },
+                set: { isPresented in
+                    if !isPresented {
+                        viewModel.dismissPendingPageDeletion()
+                    }
+                }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Delete All Visits", role: .destructive) {
+                viewModel.deletePendingPage(meili: appViewModel.meili)
+            }
+        } message: {
+            Text("This removes matching visits across all days, not just the visible section.")
+        }
         .onAppear {
-            days = CDHistoryController.fetchAll(sortDescriptors: [
-                NSSortDescriptor(keyPath: \HistoryDay.dayTime, ascending: false)
-            ])
+            viewModel.load()
+            searchFieldFocused = true
+        }
+    }
+
+    private struct EmptyStateView: View {
+        let title: String
+        let subtitle: String
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(title)
+                    .font(.title3.weight(.semibold))
+                Text(subtitle)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(18)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background {
+                RoundedRectangle(cornerRadius: 18)
+                    .fill(.ultraThinMaterial)
+            }
         }
     }
 }

--- a/Amethyst/Main/Views/History/HistoryViewModel.swift
+++ b/Amethyst/Main/Views/History/HistoryViewModel.swift
@@ -1,0 +1,109 @@
+//
+//  HistoryViewModel.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import MeiliSearch
+import SwiftUI
+
+@MainActor
+@Observable
+final class HistoryViewModel {
+    var searchText = "" {
+        didSet {
+            applyFilters()
+        }
+    }
+
+    var sections = [HistoryDaySection]()
+    var expandedPageIDs = Set<String>()
+    var pendingPageDeletion: HistoryGroupedPage?
+    var showClearAllConfirmation = false
+
+    private var allSections = [HistoryDaySection]()
+
+    var hasHistory: Bool {
+        !allSections.isEmpty
+    }
+
+    var hasSearchResults: Bool {
+        !sections.isEmpty
+    }
+
+    var resultCount: Int {
+        sections.reduce(into: 0) { partialResult, section in
+            partialResult += section.pages.count
+        }
+    }
+
+    func load() {
+        allSections = makeSections(days: CDHistoryController.fetchAllHistoryDays())
+        applyFilters()
+    }
+
+    func deleteVisit(_ visit: HistoryVisitRow, meili: MeiliSearch?) {
+        CDHistoryController.delete(visit.item)
+        HistorySearchIndexSync.syncExactURLStrings([visit.urlString], meili: meili)
+        load()
+    }
+
+    func confirmDeletePage(_ page: HistoryGroupedPage) {
+        pendingPageDeletion = page
+    }
+
+    func deletePendingPage(meili: MeiliSearch?) {
+        guard let pendingPageDeletion else { return }
+
+        let affectedURLStrings = CDHistoryController.deleteAllVisits(matchingCanonicalURL: pendingPageDeletion.canonicalURL)
+        self.pendingPageDeletion = nil
+        HistorySearchIndexSync.syncExactURLStrings(affectedURLStrings, meili: meili)
+        load()
+    }
+
+    func dismissPendingPageDeletion() {
+        pendingPageDeletion = nil
+    }
+
+    func clearAllHistory(meili: MeiliSearch?) {
+        CDHistoryController.clear()
+        showClearAllConfirmation = false
+        pendingPageDeletion = nil
+        expandedPageIDs.removeAll()
+        HistorySearchIndexSync.clearAll(meili: meili)
+        load()
+    }
+
+    private func makeSections(days: [HistoryDay]) -> [HistoryDaySection] {
+        days.compactMap { day in
+            let groupedPages = Dictionary(grouping: day.sortedItems.compactMap(HistoryVisitRow.init(item:))) { visit in
+                HistoryCanonicalizer.canonicalURLString(for: visit.url)
+            }
+            .map { key, visits in
+                HistoryGroupedPage(dayTime: day.dayTime, canonicalURL: key, visits: visits)
+            }
+            .sorted(by: { $0.lastVisitedTime > $1.lastVisitedTime })
+
+            guard !groupedPages.isEmpty else { return nil }
+            return HistoryDaySection(dayTime: day.dayTime, pages: groupedPages)
+        }
+    }
+
+    private func applyFilters() {
+        let trimmedSearch = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        if trimmedSearch.isEmpty {
+            sections = allSections
+        } else {
+            sections = allSections.compactMap { section in
+                let matchingPages = section.pages.filter { $0.matches(searchText: trimmedSearch) }
+                guard !matchingPages.isEmpty else { return nil }
+                return HistoryDaySection(dayTime: section.dayTime, pages: matchingPages)
+            }
+        }
+
+        let visiblePageIDs = Set(sections.flatMap { $0.pages.map(\.id) })
+        expandedPageIDs = expandedPageIDs.intersection(visiblePageIDs)
+    }
+}

--- a/Amethyst/Main/Views/History/HistoryVisitRow.swift
+++ b/Amethyst/Main/Views/History/HistoryVisitRow.swift
@@ -1,0 +1,39 @@
+//
+//  HistoryVisitRow.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import Foundation
+
+struct HistoryVisitRow: Identifiable {
+    let item: HistoryItem
+    let id: String
+    let rawTitle: String?
+    let displayTitle: String
+    let url: URL
+    let time: Double
+
+    init?(item: HistoryItem) {
+        guard let url = item.url else { return nil }
+
+        let trimmedTitle = item.title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let fallbackTitle = url.host ?? url.absoluteString
+
+        self.item = item
+        self.id = item.itemID?.uuidString ?? item.objectID.uriRepresentation().absoluteString
+        self.rawTitle = (trimmedTitle?.isEmpty == false) ? trimmedTitle : nil
+        self.displayTitle = rawTitle ?? fallbackTitle
+        self.url = url
+        self.time = item.time
+    }
+
+    var urlString: String {
+        url.absoluteString
+    }
+
+    var host: String {
+        url.host ?? url.absoluteString
+    }
+}

--- a/Amethyst/Shared/CoreData/History/CDHistoryController+History.swift
+++ b/Amethyst/Shared/CoreData/History/CDHistoryController+History.swift
@@ -1,0 +1,115 @@
+//
+//  CDHistoryController+History.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import CoreData
+import Foundation
+
+extension CDHistoryController {
+    func fetchAllHistoryDays() -> [HistoryDay] {
+        let request = HistoryDay.createFetchRequest()
+        request.includesSubentities = false
+        request.relationshipKeyPathsForPrefetching = ["historyItems"]
+        request.sortDescriptors = [
+            NSSortDescriptor(keyPath: \HistoryDay.dayTime, ascending: false)
+        ]
+
+        do {
+            return try container.viewContext.fetch(request)
+        } catch {
+            Self.logger.error("Error while fetching all prefetched HistoryDays: \(error.localizedDescription)")
+        }
+        return []
+    }
+
+    func deleteAllVisits(matchingCanonicalURL canonicalURL: String) -> [String] {
+        let items = fetchAllHistoryItems().filter {
+            guard let url = $0.url else { return false }
+            return HistoryCanonicalizer.canonicalURLString(for: url) == canonicalURL
+        }
+        let affectedURLStrings = Array(Set(items.compactMap { $0.url?.absoluteString })).sorted()
+
+        guard !items.isEmpty else { return [] }
+
+        items.forEach { container.viewContext.delete($0) }
+        save()
+        pruneEmptyDays()
+        return affectedURLStrings
+    }
+
+    func clearEntity() {
+        fetchAllHistoryDays().forEach {
+            container.viewContext.delete($0)
+        }
+        save()
+    }
+
+    func fetchSearchIndexSnapshots(for urlStrings: [String]) async -> [HistorySearchIndexSnapshot] {
+        let uniqueURLStrings = Array(Set(urlStrings.filter({ !$0.isEmpty }))).sorted()
+        guard !uniqueURLStrings.isEmpty else { return [] }
+
+        return await withCheckedContinuation { continuation in
+            container.performBackgroundTask { context in
+                continuation.resume(returning: uniqueURLStrings.map {
+                    Self.makeSearchIndexSnapshot(urlString: $0, context: context)
+                })
+            }
+        }
+    }
+
+    private func fetchAllHistoryItems() -> [HistoryItem] {
+        let request = HistoryItem.createFetchRequest()
+        request.sortDescriptors = [
+            NSSortDescriptor(keyPath: \HistoryItem.time, ascending: false)
+        ]
+
+        do {
+            return try container.viewContext.fetch(request)
+        } catch {
+            Self.logger.error("Error while fetching all HistoryItems: \(error.localizedDescription)")
+        }
+        return []
+    }
+
+    private static func makeSearchIndexSnapshot(
+        urlString: String,
+        context: NSManagedObjectContext
+    ) -> HistorySearchIndexSnapshot {
+        guard let url = URL(string: urlString) else {
+            return HistorySearchIndexSnapshot(urlString: urlString, entry: nil)
+        }
+
+        let request = HistoryItem.createFetchRequest()
+        request.predicate = NSPredicate(format: "url == %@", url as CVarArg)
+        request.sortDescriptors = [
+            NSSortDescriptor(keyPath: \HistoryItem.time, ascending: false)
+        ]
+
+        do {
+            let items = try context.fetch(request)
+            guard let latestItem = items.first else {
+                return HistorySearchIndexSnapshot(urlString: urlString, entry: nil)
+            }
+
+            let title = items
+                .compactMap(\.title)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first(where: { !$0.isEmpty }) ?? ""
+            let entry = HistoryEntry(
+                id: UUID(),
+                title: title,
+                url: urlString,
+                lastSeen: Int(latestItem.time.rounded()),
+                amount: items.count
+            )
+
+            return HistorySearchIndexSnapshot(urlString: urlString, entry: entry)
+        } catch {
+            Self.logger.error("Error while creating History search index snapshot: \(error.localizedDescription)")
+            return HistorySearchIndexSnapshot(urlString: urlString, entry: nil)
+        }
+    }
+}

--- a/Amethyst/Shared/CoreData/History/CDHistoryController.swift
+++ b/Amethyst/Shared/CoreData/History/CDHistoryController.swift
@@ -12,8 +12,8 @@ import OSLog
 class CDHistoryController {
     public static var shared = CDHistoryController(name: "History")
     var container: NSPersistentContainer
-    private static var logger = Logger(subsystem: AmethystApp.subSystem, category: "CDHistroryController")
-    
+    static var logger = Logger(subsystem: AmethystApp.subSystem, category: "CDHistroryController")
+
     private init(name: String) {
         container = NSPersistentContainer(name: name)
         container.loadPersistentStores { _, error in
@@ -22,7 +22,7 @@ class CDHistoryController {
             }
         }
     }
-    
+
     func fetchAll(sortDescriptors: [NSSortDescriptor] = []) -> [HistoryDay] {
         let request = HistoryDay.createFetchRequest()
         request.includesSubentities = false
@@ -34,43 +34,22 @@ class CDHistoryController {
         }
         return []
     }
-    
+
     func delete(_ item: HistoryItem) {
         container.viewContext.delete(item)
         save()
+        pruneEmptyDays()
     }
-    
-    func clearEntity() {
-        container.performBackgroundTask { context in
-            let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: "HistoryDay")
-            let batchDeleteRequest = NSBatchDeleteRequest(fetchRequest: fetchRequest)
-            batchDeleteRequest.resultType = .resultTypeObjectIDs
 
-            do {
-                let result = try context.execute(batchDeleteRequest) as? NSBatchDeleteResult
-                
-                if let objectIDs = result?.result as? [NSManagedObjectID] {
-                    let changes = [NSDeletedObjectsKey: objectIDs]
-                    NSManagedObjectContext.mergeChanges(
-                        fromRemoteContextSave: changes,
-                        into: [self.container.viewContext]
-                    )
-                }
-            } catch {
-                Self.logger.error("An error occured while emptying HistoryDay: \(error.localizedDescription)")
-            }
-        }
-    }
-    
     func printKnownEntities() {
         Self.logger.info("Known Entities: \(self.container.managedObjectModel.entities.compactMap(\.name))")
     }
-    
+
     func insertHistoryDay(_ day: HistoryDay) {
         container.viewContext.insert(day)
         save()
     }
-    
+
     func save() {
         if container.viewContext.hasChanges {
             do {
@@ -80,7 +59,7 @@ class CDHistoryController {
             }
         }
     }
-    
+
     func dayFetchCount(_ predicate: Predicate<HistoryDay>) -> Int {
         let request = HistoryDay.createFetchRequest()
         request.predicate = NSPredicate(predicate)
@@ -91,7 +70,7 @@ class CDHistoryController {
         }
         return 0
     }
-    
+
     func itemFetchCount(_ predicate: Predicate<HistoryItem>) -> Int {
         let request = HistoryItem.createFetchRequest()
         request.predicate = NSPredicate(predicate)
@@ -102,7 +81,7 @@ class CDHistoryController {
         }
         return 0
     }
-    
+
     func fetchOrCreateHistoryDay() -> HistoryDay {
         let rangeStart = Calendar.current.startOfDay(for: Date.now).timeIntervalSinceReferenceDate
 
@@ -112,14 +91,14 @@ class CDHistoryController {
             $0.dayTime == rangeStart
         })
         request.fetchLimit = 1
-        
+
         do {
             if let day = try container.viewContext.fetch(request).first { return day }
         } catch {
             Self.logger.log("Failed to create HistoryDay: \(error.localizedDescription)")
         }
         return createAndSaveHistoryDay(rangeStart: rangeStart)
-        
+
         func createAndSaveHistoryDay(rangeStart: Double) -> HistoryDay {
             let day = HistoryDay()
             day.dayTime = rangeStart
@@ -127,40 +106,60 @@ class CDHistoryController {
             return day
         }
     }
-    
+
+    func pruneEmptyDays() {
+        let emptyDays = fetchAllHistoryDays().filter { $0.sortedItems.isEmpty }
+        guard !emptyDays.isEmpty else { return }
+
+        emptyDays.forEach { container.viewContext.delete($0) }
+        save()
+    }
+
 }
 
 extension CDHistoryController {
+    static func fetchAllHistoryDays() -> [HistoryDay] {
+        CDHistoryController.shared.fetchAllHistoryDays()
+    }
+
     static func fetchAll(sortDescriptors: [NSSortDescriptor] = []) -> [HistoryDay] {
         CDHistoryController.shared.fetchAll(sortDescriptors: sortDescriptors)
     }
-    
+
     static func save() {
         CDHistoryController.shared.save()
     }
-    
+
     static func insertHistoryDay(_ day: HistoryDay) {
         CDHistoryController.shared.insertHistoryDay(day)
     }
-    
+
     static func clear() {
         CDHistoryController.shared.clearEntity()
     }
-    
+
+    static func deleteAllVisits(matchingCanonicalURL canonicalURL: String) -> [String] {
+        CDHistoryController.shared.deleteAllVisits(matchingCanonicalURL: canonicalURL)
+    }
+
+    static func fetchSearchIndexSnapshots(for urlStrings: [String]) async -> [HistorySearchIndexSnapshot] {
+        await CDHistoryController.shared.fetchSearchIndexSnapshots(for: urlStrings)
+    }
+
     static func dayFetchCount(_ predicate: Predicate<HistoryDay>) -> Int {
         CDHistoryController.shared.dayFetchCount(predicate)
     }
-    
+
     static func itemFetchCount(_ predicate: Predicate<HistoryItem>) -> Int {
         CDHistoryController.shared.itemFetchCount(predicate)
     }
-    
+
     static func delete(_ item: HistoryItem) {
         CDHistoryController.shared.delete(item)
     }
-    
+
     static var currentHistoryDay: HistoryDay {
         CDHistoryController.shared.fetchOrCreateHistoryDay()
     }
-    
+
 }

--- a/Amethyst/Shared/CoreData/History/HistorySearchIndexSnapshot.swift
+++ b/Amethyst/Shared/CoreData/History/HistorySearchIndexSnapshot.swift
@@ -1,0 +1,13 @@
+//
+//  HistorySearchIndexSnapshot.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import Foundation
+
+struct HistorySearchIndexSnapshot {
+    let urlString: String
+    let entry: HistoryEntry?
+}

--- a/Amethyst/Shared/CoreData/History/HistorySearchIndexSync.swift
+++ b/Amethyst/Shared/CoreData/History/HistorySearchIndexSync.swift
@@ -1,0 +1,152 @@
+//
+//  HistorySearchIndexSync.swift
+//  Amethyst Browser
+//
+//  Created by Codex on 28.03.26.
+//
+
+import Foundation
+import MeiliSearch
+import OSLog
+
+enum HistorySearchIndexSync {
+    private static let historyIndexUID = "history"
+    private static let logger = Logger(subsystem: AmethystApp.subSystem, category: "HistorySearchIndexSync")
+
+    static func syncExactURLStrings(_ urlStrings: [String], meili: MeiliSearch?) {
+        guard let meili else { return }
+
+        let uniqueURLStrings = Array(Set(urlStrings.filter({ !$0.isEmpty }))).sorted()
+        guard !uniqueURLStrings.isEmpty else { return }
+
+        Swift.Task(priority: .background) {
+            let snapshots = await CDHistoryController.fetchSearchIndexSnapshots(for: uniqueURLStrings)
+            await performWithPreparedIndex(meili: meili, createIfMissing: true) { index in
+                for snapshot in snapshots {
+                    let existingEntries = try await fetchEntries(urlString: snapshot.urlString, index: index)
+                    try await sync(snapshot: snapshot, existingEntries: existingEntries, index: index)
+                }
+            }
+        }
+    }
+
+    static func clearAll(meili: MeiliSearch?) {
+        guard let meili else { return }
+
+        Swift.Task(priority: .background) {
+            let index = meili.index(historyIndexUID)
+            do {
+                _ = try await index.deleteAllDocuments()
+            } catch let error as MeiliSearch.Error {
+                if shouldPrepareIndex(for: error) {
+                    return
+                }
+                logger.error("Failed clearing Meili history index: \(error.localizedDescription)")
+            } catch {
+                logger.error("Failed clearing Meili history index: \(error.localizedDescription)")
+            }
+        }
+    }
+
+    private static func sync(
+        snapshot: HistorySearchIndexSnapshot,
+        existingEntries: [SearchHit<HistoryEntryResult>],
+        index: Indexes
+    ) async throws {
+        if let entry = snapshot.entry {
+            let documentID = existingEntries.first?.id ?? entry.id
+            let syncedEntry = HistoryEntry(
+                id: documentID,
+                title: entry.title,
+                url: entry.url,
+                lastSeen: entry.lastSeen,
+                amount: entry.amount
+            )
+
+            if existingEntries.isEmpty {
+                _ = try await index.addDocuments(documents: [syncedEntry], primaryKey: "id")
+            } else {
+                _ = try await index.updateDocuments(documents: [syncedEntry], primaryKey: "id")
+            }
+
+            let duplicateIDs = existingEntries.dropFirst().map { $0.id.uuidString }
+            if !duplicateIDs.isEmpty {
+                _ = try await index.deleteBatchDocuments(duplicateIDs)
+            }
+        } else {
+            let existingIDs = existingEntries.map { $0.id.uuidString }
+            if !existingIDs.isEmpty {
+                _ = try await index.deleteBatchDocuments(existingIDs)
+            }
+        }
+    }
+
+    private static func fetchEntries(
+        urlString: String,
+        index: Indexes
+    ) async throws -> [SearchHit<HistoryEntryResult>] {
+        let searchResult: Searchable<HistoryEntryResult> = try await index.search(SearchParameters(
+            query: urlString,
+            limit: 20,
+            attributesToSearchOn: ["url"],
+            filter: "url = '\(escapedFilterValue(urlString))'"
+        ))
+        return searchResult.hits
+    }
+
+    private static func performWithPreparedIndex(
+        meili: MeiliSearch,
+        createIfMissing: Bool,
+        operation: @escaping (Indexes) async throws -> Void
+    ) async {
+        let index = meili.index(historyIndexUID)
+        do {
+            try await operation(index)
+        } catch let error as MeiliSearch.Error {
+            guard createIfMissing, shouldPrepareIndex(for: error) else {
+                logger.error("Failed syncing Meili history index: \(error.localizedDescription)")
+                return
+            }
+
+            do {
+                try await prepareIndex(meili)
+                try await operation(index)
+            } catch let retryError as MeiliSearch.Error {
+                logger.error("Failed syncing Meili history index after reconfiguring index: \(retryError.localizedDescription)")
+            } catch {
+                logger.error("Failed syncing Meili history index after reconfiguring index: \(error.localizedDescription)")
+            }
+        } catch {
+            logger.error("Failed syncing Meili history index: \(error.localizedDescription)")
+        }
+    }
+
+    private static func prepareIndex(_ meili: MeiliSearch) async throws {
+        do {
+            _ = try await meili.createIndex(uid: historyIndexUID, primaryKey: "id")
+        } catch let error as MeiliSearch.Error {
+            let description = error.localizedDescription
+            if !description.contains("already exists") && !description.contains("already in use") {
+                throw error
+            }
+        }
+
+        let index = meili.index(historyIndexUID)
+        _ = try await index.updateSearchableAttributes(["url", "title"])
+        _ = try await index.updateFilterableAttributes(["url", "title", "id", "lastSeen", "amount"])
+        _ = try await index.updateSortableAttributes(["lastSeen", "amount"])
+    }
+
+    private static func shouldPrepareIndex(for error: MeiliSearch.Error) -> Bool {
+        let description = error.localizedDescription
+        return description.contains("Index `history` not found") ||
+        description.contains("is not filterable") ||
+        description.contains("is not searchable")
+    }
+
+    private static func escapedFilterValue(_ value: String) -> String {
+        value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "'", with: "\\'")
+    }
+}

--- a/Amethyst/Shared/ViewComponents/WebKit/WebViewModel.swift
+++ b/Amethyst/Shared/ViewComponents/WebKit/WebViewModel.swift
@@ -24,14 +24,14 @@ class WebViewModel: NSObject, ObservableObject {
     @Published var blockDownloadCheckforURL: URL? = nil
     @ObservedObject var contentViewModel: ContentViewModel
     @ObservedObject var appViewModel: AppViewModel
-    
+
     var referer: String? = nil
-    
+
     var historyBlocked: [URL: Double] = [:]
     var webView: AWKWebView?
     var cancellables: Set<AnyCancellable> = []
     var cache: Bool? = nil
-    
+
     // MARK: - Initializers
 
     // This is the new Designated Initializer. It's the most fundamental one.
@@ -50,7 +50,7 @@ class WebViewModel: NSObject, ObservableObject {
         self.setupBindings()
         self.injectAllJS()
     }
-    
+
     // Convenience init for a standard new tab.
     // It derives the processPool from the contentViewModel.
     convenience init(contentViewModel: ContentViewModel, appViewModel: AppViewModel) {
@@ -58,7 +58,7 @@ class WebViewModel: NSObject, ObservableObject {
         // No special configuration needed, so we call the designated init directly.
         self.init(configuration: config, contentViewModel: contentViewModel, appViewModel: appViewModel)
     }
-    
+
     init(config: WKWebViewConfiguration, contentViewModel: ContentViewModel, appViewModel: AppViewModel) {
         self.contentViewModel = contentViewModel
         self.appViewModel = appViewModel
@@ -70,28 +70,28 @@ class WebViewModel: NSObject, ObservableObject {
         self.webView?.navigationDelegate = self
         self.webView?.allowsLinkPreview = true
         self.webView?.isInspectable = true
-        
+
         setupBindings()
         injectAllJS()
     }
-    
+
     deinit {
         webView?.stopLoading()
-        
+
         let userContentController = webView?.configuration.userContentController
         userContentController?.removeAllUserScripts()
         userContentController?.removeScriptMessageHandler(forName: "webauthn")
-        
+
         webView?.uiDelegate = nil
         webView?.navigationDelegate = nil
-        
+
         cancellables.forEach { $0.cancel() }
         cancellables.removeAll()
-        
+
         webView?.removeFromSuperview()
         webView = nil
     }
-    
+
     func cleanup() async {
         // 1. Perform all async cleanup operations first.
         // We can safely await them here because we are in an async context
@@ -121,20 +121,20 @@ class WebViewModel: NSObject, ObservableObject {
         webView?.removeFromSuperview()
         webView = nil
     }
-    
+
     func goBack() {
         if canGoBack {
             webView?.goBack()
         }
     }
-    
+
     func goForward() {
         if canGoForward {
             webView?.goForward()
         }
     }
 
-    
+
     func getWebView() -> WKWebView {
         if let webView {
             return webView
@@ -146,32 +146,29 @@ class WebViewModel: NSObject, ObservableObject {
             self.webView?.underPageBackgroundColor = .myPurple
             self.webView?.allowsLinkPreview = true
             setupBindings()
-    
+
             return webView
         }
     }
-    
+
     func load(urlString: String) {
         guard let url = URL(string: urlString) else { return }
         load(url: url)
     }
-    
+
     func load(url: URL) {
         var request = URLRequest(url: url)
         request.setValue("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/26.1 Safari/605.1.15", forHTTPHeaderField: "User-Agent")
         request.setValue(Self.accept, forHTTPHeaderField: "Accept")
         webView?.load(request)
     }
-    
+
     func appendHistory() {
         if let url = currentURL, cache != nil {
             if let blockedTime = historyBlocked[url], blockedTime > Date().timeIntervalSinceReferenceDate {
                 return
             }
-            if let meili = appViewModel.meili {
-                addToHistory(meili: meili, url: url)
-            }
-            
+
             let day = CDHistoryController.currentHistoryDay
             let item = HistoryItem()
             item.time = Date.now.timeIntervalSinceReferenceDate
@@ -179,45 +176,15 @@ class WebViewModel: NSObject, ObservableObject {
             item.title = title
             day.addHistoryItem(item)
             CDHistoryController.save()
-           
+
+            if let meili = appViewModel.meili {
+                HistorySearchIndexSync.syncExactURLStrings([url.absoluteString], meili: meili)
+            }
+
             historyBlocked[url] = Date.now.timeIntervalSinceReferenceDate + 300
         }
     }
-    
-    func addToHistory(meili: MeiliSearch, url: URL) {
-        typealias MeiliResult = Searchable<HistoryEntry>
-        SwiftUI.Task(priority: .background) {
-            let index = meili.index("history")
-            let param = SearchParameters(query: url.absoluteString, limit: 1, attributesToSearchOn: ["url"], filter: "url = '\(url.absoluteString)'")
-            do {
-                let result: MeiliResult = try await index.search(param)
-                if let res = result.hits.first {
-                    let new = HistoryEntry(id: res.id, title: self.title ?? res.title, url: res.url, lastSeen: Int(Date.now.timeIntervalSinceReferenceDate), amount: res.amount + 1)
-                    _ = try await index.updateDocuments(documents: [new], primaryKey: "id")
-                } else {
-                    let new = HistoryEntry(id: UUID(), title: self.title ?? "", url: url.absoluteString, lastSeen: Int(Date.now.timeIntervalSinceReferenceDate), amount: 1)
-                    _ = try await index.addDocuments(documents: [new], primaryKey: "id")
-                }
-            } catch let error as MeiliSearch.Error {
-                Self.logger.error("Error occured while appending Meili history: \(error.localizedDescription)")
-                if error.localizedDescription.contains("MeiliSearchApiError: Index `history` not found.") ||
-                    error.localizedDescription.contains("is not filterable") ||
-                    error.localizedDescription.contains("is not searchable") {
-                    do {
-                        _ = try await meili.createIndex(uid: "history", primaryKey: "id")
-                        _ = try await meili.index("history").updateSearchableAttributes(["url", "title"])
-                        _ = try await meili.index("history").updateFilterableAttributes(["url", "title", "id", "lastSeen", "amount"])
-                        _ = try await meili.index("history").updateSortableAttributes(["lastSeen", "amount"])
-                        let new = HistoryEntry(id: UUID(), title: self.title ?? "", url: url.absoluteString, lastSeen: Int(Date.now.timeIntervalSinceReferenceDate), amount: 1)
-                        _ = try await index.addDocuments(documents: [new], primaryKey: "id")
-                    } catch {
-                        Self.logger.error("Error occured while configuring Meili index: \(error.localizedDescription)")
-                    }
-                }
-            }
-        }
-    }
-    
+
     func setupBindings() {
         webView?.publisher(for: \.canGoBack)
             .receive(on: DispatchQueue.main)
@@ -255,14 +222,14 @@ class WebViewModel: NSObject, ObservableObject {
                 self?.title = value
             }
             .store(in: &cancellables)
-        
+
         webView?.publisher(for: \.cameraCaptureState)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
                 self?.isUsingCamera = value
             }
             .store(in: &cancellables)
-        
+
         webView?.publisher(for: \.microphoneCaptureState)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] value in
@@ -270,13 +237,13 @@ class WebViewModel: NSObject, ObservableObject {
             }
             .store(in: &cancellables)
     }
-    
+
     private func injectAllJS() {
         injectJavaScript()
         injectCSSGlobally()
         injectAutofillCode()
     }
-   
+
     // MARK: - Private Helper Methods
 
     /// Configures the common properties of the AWKWebView instance.
@@ -322,15 +289,15 @@ class WebViewModel: NSObject, ObservableObject {
 
         return webConfiguration
     }
-    
+
 }
 
 extension WebViewModel: WKScriptMessageHandlerWithReply {
-    
+
     func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) async -> (Any?, String?) {
         print(message.body)
         return (false, "whatever")
     }
-    
-    
+
+
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,12 @@ To maintain the privacy and security of our users, **you are strictly prohibited
 
 Xcode will handle the build process. Simply select the target and click the "Run" button.
 
+If Xcode signing fails on a personal Apple development team because the browser target uses capabilities that are not supported there, you can still build locally from the command line without code signing:
+
+```bash
+xcodebuild -project 'Amethyst Project.xcodeproj' -scheme 'Amethyst Debug' -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
+```
+
 ## Testing
 
 Currently, Amethyst does not have extensive unit tests due to the challenges of testing UI-heavy applications. Therefore, it is crucial that you thoroughly test your changes manually.


### PR DESCRIPTION
## Summary

- Add local-first searchable history with grouped page rows and inline visit drilldown
- Support single-visit delete, page delete, and clear-all history
- Keep Meili history suggestions in sync with Core Data

## Verification

- Built with: xcodebuild -project 'Amethyst Project.xcodeproj' -scheme 'Amethyst Debug' -configuration Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO build
- Manually tested history search, grouping, delete flows, outside-click dismissal, and resizing