### PR TITLE
Dev

### DIFF
--- a/Amethyst/Main/ContentViewModel.swift
+++ b/Amethyst/Main/ContentViewModel.swift
@@ -123,6 +123,7 @@ struct ContentView {
         }
         if contentViewModel.tabs.isEmpty {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                var tabs = contentViewModel.tabs
                 let savedTabs = CDTabController.fetchAllFor(windowID: contentViewModel.id)
                 
                 var memoizedIDs = [UUID]()
@@ -134,8 +135,10 @@ struct ContentView {
                     let vm = WebViewModel(contentViewModel: contentViewModel, appViewModel: appViewModel)
                     vm.load(urlString: savedTab.url?.absoluteString ?? "about:blank")
                     let newTab = ATab(id: id, webViewModel: vm)
-                    contentViewModel.tabs.append(newTab)
+                    tabs.append(newTab)
                 }
+                
+                contentViewModel.tabs = tabs
                 CDTabController.deleteFor(windowID: contentViewModel.id)
                 contentViewModel.isSidebarFixed = true
             }

--- a/Amethyst/Main/Views/Sidebar/Children/ShortDownloadOverviewItem.swift
+++ b/Amethyst/Main/Views/Sidebar/Children/ShortDownloadOverviewItem.swift
@@ -42,8 +42,12 @@ struct ShortDownloadOverviewItem: View {
         }
         .onHover { hovering in isHovered = hovering }
         .onTapGesture { if let url = item.url { NSWorkspace.shared.open(url) } }
-        .if(isHovered && appearance == .dark) { view in view.background(.regularMaterial) }
-        .if(isHovered && appearance == .light) { view in view.background(.white.mix(with: .gray, by: 0.05)) }
+        .if(isHovered && appearance == .dark) { view in
+            view.background(.myPurple.mix(with: .white, by: 0.25))
+        }
+        .if(isHovered && appearance == .light) { view in
+            view.background(.white.mix(with: .gray, by: 0.05))
+        }
         .clipShape(RoundedRectangle(cornerRadius: 10))
         .contextMenu {
             if item.info?.progress == nil {

--- a/Amethyst/Main/Views/Sidebar/Sidebar.swift
+++ b/Amethyst/Main/Views/Sidebar/Sidebar.swift
@@ -35,16 +35,14 @@ struct Sidebar: View {
                         DownloadOverview()
                     }
             }
-            ZStack {
-                if(!AppViewModel.isDefaultBrowser()) {
-                    VStack {
-                        Spacer()
-                        SetDefaultBrowserButton()
-                    }
+            if(!AppViewModel.isDefaultBrowser()) {
+                VStack {
+                    Spacer()
+                    SetDefaultBrowserButton()
                 }
-                MenuButton()
-                .placeBottomLeading()
             }
+            MenuButton()
+            .placeBottomLeading()
         }
         .decideSidebarStyling(isFixed: contentViewModel.isSidebarFixed, appearance: appearance, useMacos26Desing: appViewModel.useMacOS26Design)
     }
@@ -129,6 +127,8 @@ struct Sidebar: View {
     private struct NewTabButton: View {
         @Environment(ContentViewModel.self) var contentViewModel
         @State var isNewTabHovered: Bool = false
+        @Environment(\.colorScheme) var appearance
+        
         var body: some View {
             Button { contentViewModel.triggerNewTab.toggle() } label: {
                 HStack {
@@ -140,7 +140,11 @@ struct Sidebar: View {
                 .padding(10)
                 .background {
                     RoundedRectangle(cornerRadius: 12)
-                        .fill(true: .mainColorMix.opacity(0.1), false: .ultraThinMaterial, with: isNewTabHovered)
+                        .fill(
+                            true: .mainColorMix.opacity(0.1),
+                            false: .black.opacity(appearance == .dark ? 0.1: 0.05),
+                            with: isNewTabHovered
+                        )
                 }
             }
             .buttonStyle(.plain)

--- a/Amethyst/Shared/ViewComponents/Sidebar/URLDisplay/URLDisplay.swift
+++ b/Amethyst/Shared/ViewComponents/Sidebar/URLDisplay/URLDisplay.swift
@@ -1,9 +1,3 @@
-//
-//  URLDisplay.swift
-//  Amethyst
-//
-//  Created by Mia Koring on 28.11.24.
-//
 import SwiftUI
 
 extension URLDisplay: View {
@@ -29,8 +23,7 @@ extension URLDisplay: View {
         .padding(10)
         .background() {
             RoundedRectangle(cornerRadius: 12)
-                .fill(.thinMaterial)
-                .background(.mainColorMix.opacity(appearance == .dark ? 0.2: 0.05))
+                .fill(.black.opacity(appearance == .dark ? 0.1: 0.05))
                 .clipShape(RoundedRectangle(cornerRadius: 12))
                 .onTapGesture {
                     if !showTextField {

--- a/Amethyst/Shared/ViewComponents/WebKit/Delegates/WKDownloadDelegate.swift
+++ b/Amethyst/Shared/ViewComponents/WebKit/Delegates/WKDownloadDelegate.swift
@@ -32,10 +32,12 @@ extension WebViewModel: WKDownloadDelegate {
     }
     
     private func animateDownloadStart() {
-        downloadCreatedTimer?.invalidate()
-        downloadCreatedTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { [weak self] timer in
-            timer.invalidate()
-            self?.downloadCreatedTimer = nil
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.downloadCreatedTimer?.invalidate()
+            self.downloadCreatedTimer = Timer.scheduledTimer(withTimeInterval: 3, repeats: false) { [weak self] _ in
+                self?.downloadCreatedTimer = nil
+            }
         }
     }
     

--- a/Amethyst/Shared/ViewComponents/WebKit/WebView.swift
+++ b/Amethyst/Shared/ViewComponents/WebKit/WebView.swift
@@ -39,9 +39,7 @@ struct WebView: View {
     }
     
     private func focusIfActive(){
-        if contentViewModel.currentTab == tabID {
-            isFocused = true
-        }
+        isFocused = (contentViewModel.currentTab == tabID)
     }
     
     private struct ErrorView: View {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview
This PR includes UI refinements, styling updates, and code simplifications across the Amethyst browser application, spanning sidebar components, download handling, and view management.

## Key Changes

### Tab Restoration Optimization
ContentViewModel now builds restored tabs in a local array before assignment, reducing repeated mutations to `contentViewModel.tabs` during the restoration loop.

### UI Styling Updates
- **ShortDownloadOverviewItem**: Hover styling refined with dark mode support using custom color mixing (`.myPurple.mix(with: .white, by: 0.25)`)
- **Sidebar**: Layout restructured to improve component positioning; `NewTabButton` now uses conditional opacity-based backgrounds instead of material effects

### Code Quality Improvements
**URLDisplay** - Container background rendering significantly simplified by removing `.thinMaterial` and secondary opacity layers in favor of a single black color with appearance-based opacity. This is notably cleaner and more maintainable.

**WKDownloadDelegate** - Timer management improved with proper main actor enforcement using `Task { @MainActor }` and early guard clause for weak self capture, ensuring thread-safe timer operations.

**WebView** - Focus state handling refactored to use a single boolean expression instead of conditional logic, making the code more concise and explicit.

## Impact
- Consistent main actor usage in async operations
- Reduced visual complexity through material effect removal
- Cleaner, more maintainable code patterns
- Improved dark mode styling consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->